### PR TITLE
Add 'use strict'.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const gitConfig = require('git-config');
 const Generator = require('yeoman-generator');
 const titleCase = require('title-case');


### PR DESCRIPTION
```
/home/patcon/.nvm/versions/node/v5.3.0/lib/node_modules/generator-awesome-list/app/index.js:5
class GeneratorAwesomeList extends Generator {
^^^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```

Getting the above issue with node v5.3, and manually adding `'use strict';` to the top of index.js resolved it :)

